### PR TITLE
feat: add Aave V4 decoder and sanitizer

### DIFF
--- a/src/base/DecodersAndSanitizers/MilkAvaxAIDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/MilkAvaxAIDecoderAndSanitizer.sol
@@ -3,32 +3,42 @@ pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {AaveV3DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/AaveV3DecoderAndSanitizer.sol";
+import {AaveV4DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol";
 import {AesyxBorrowerOperations} from "src/base/DecodersAndSanitizers/Protocols/aesyx/AesyxBorrowerOperations.sol";
 import {AesyxWrapper} from "src/base/DecodersAndSanitizers/Protocols/aesyx/AesyxWrapper.sol";
-import {BenqiLendingDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/benqi/BenqiLendingDecoderAndSanitizer.sol";
-import {BlackholeDecoderAndSanitizer} from
-    "src/base/DecodersAndSanitizers/Protocols/BlackholeDecoderAndSanitizer.sol";
-import {DeltaPrimeDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/DeltaPrimeDecoderAndSanitizer.sol";
+import {
+    BenqiLendingDecoderAndSanitizer
+} from "src/base/DecodersAndSanitizers/Protocols/benqi/BenqiLendingDecoderAndSanitizer.sol";
+import {BlackholeDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/BlackholeDecoderAndSanitizer.sol";
+import {
+    DeltaPrimeDecoderAndSanitizer
+} from "src/base/DecodersAndSanitizers/Protocols/DeltaPrimeDecoderAndSanitizer.sol";
 import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol";
-import {LFJLBRouterDecoderAndSanitizer} from
-    "src/base/DecodersAndSanitizers/Protocols/LFJLBRouterDecoderAndSanitizer.sol";
-import {LFJLBHooksSimpleRewarderDecoderAndSanitizer} from
-    "src/base/DecodersAndSanitizers/Protocols/LFJLBHooksSimpleRewarderDecoderAndSanitizer.sol";
-import {LFJLBPairDecoderAndSanitizer} from
-    "src/base/DecodersAndSanitizers/Protocols/LFJLBPairDecoderAndSanitizer.sol";
-import {MasterChefDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/MasterChefDecoderAndSanitizer.sol";
+import {
+    LFJLBRouterDecoderAndSanitizer
+} from "src/base/DecodersAndSanitizers/Protocols/LFJLBRouterDecoderAndSanitizer.sol";
+import {
+    LFJLBHooksSimpleRewarderDecoderAndSanitizer
+} from "src/base/DecodersAndSanitizers/Protocols/LFJLBHooksSimpleRewarderDecoderAndSanitizer.sol";
+import {LFJLBPairDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/LFJLBPairDecoderAndSanitizer.sol";
+import {
+    MasterChefDecoderAndSanitizer
+} from "src/base/DecodersAndSanitizers/Protocols/MasterChefDecoderAndSanitizer.sol";
 import {MerklDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/MerklDecoderAndSanitizer.sol";
-import {NativeWrapperDecoderAndSanitizer} from
-    "src/base/DecodersAndSanitizers/Protocols/NativeWrapperDecoderAndSanitizer.sol";
+import {
+    NativeWrapperDecoderAndSanitizer
+} from "src/base/DecodersAndSanitizers/Protocols/NativeWrapperDecoderAndSanitizer.sol";
 import {SiloIncentivesController} from "src/base/DecodersAndSanitizers/Protocols/silo/SiloIncentivesController.sol";
-import {StableJackDecoderAndSanitizer} from
-    "src/base/DecodersAndSanitizers/Protocols/StableJackDecoderAndSanitizer.sol";
-import {YakMilkDecoderAndSanitizer} from
-    "src/base/DecodersAndSanitizers/Protocols/YakMilkDecoderAndSanitizer.sol";
-import {YakStrategyDecoderAndSanitizer} from
-    "src/base/DecodersAndSanitizers/Protocols/YakStrategyDecoderAndSanitizer.sol";
-import {YakSimpleSwapDecoderAndSanitizer} from
-    "src/base/DecodersAndSanitizers/Protocols/YakSimpleSwapDecoderAndSanitizer.sol";
+import {
+    StableJackDecoderAndSanitizer
+} from "src/base/DecodersAndSanitizers/Protocols/StableJackDecoderAndSanitizer.sol";
+import {YakMilkDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/YakMilkDecoderAndSanitizer.sol";
+import {
+    YakStrategyDecoderAndSanitizer
+} from "src/base/DecodersAndSanitizers/Protocols/YakStrategyDecoderAndSanitizer.sol";
+import {
+    YakSimpleSwapDecoderAndSanitizer
+} from "src/base/DecodersAndSanitizers/Protocols/YakSimpleSwapDecoderAndSanitizer.sol";
 
 contract MilkAvaxAIDecoderAndSanitizer is
     BaseDecoderAndSanitizer,
@@ -49,12 +59,10 @@ contract MilkAvaxAIDecoderAndSanitizer is
     StableJackDecoderAndSanitizer,
     YakMilkDecoderAndSanitizer,
     YakStrategyDecoderAndSanitizer,
-    YakSimpleSwapDecoderAndSanitizer
+    YakSimpleSwapDecoderAndSanitizer,
+    AaveV4DecoderAndSanitizer
 {
-    constructor(
-        address _boringVault,
-        address _blackholeNonFungiblePositionManager
-    ) 
+    constructor(address _boringVault, address _blackholeNonFungiblePositionManager)
         BaseDecoderAndSanitizer(_boringVault)
         BlackholeDecoderAndSanitizer(_blackholeNonFungiblePositionManager)
     {}
@@ -105,12 +113,7 @@ contract MilkAvaxAIDecoderAndSanitizer is
     function mintToken(
         DecoderCustomTypes.StableJackGroupKey calldata groupKey,
         DecoderCustomTypes.StableJackMintParams calldata params
-    )
-        external
-        pure
-        override(StableJackDecoderAndSanitizer)
-        returns (bytes memory addressesFound)
-    {
+    ) external pure override(StableJackDecoderAndSanitizer) returns (bytes memory addressesFound) {
         addressesFound = abi.encodePacked(
             groupKey.core.aToken,
             groupKey.core.xToken,
@@ -124,12 +127,7 @@ contract MilkAvaxAIDecoderAndSanitizer is
     function redeemToken(
         DecoderCustomTypes.StableJackGroupKey calldata groupKey,
         DecoderCustomTypes.StableJackRedeemParams calldata params
-    )
-        external
-        pure
-        override(StableJackDecoderAndSanitizer)
-        returns (bytes memory addressesFound)
-    {
+    ) external pure override(StableJackDecoderAndSanitizer) returns (bytes memory addressesFound) {
         addressesFound = abi.encodePacked(
             groupKey.core.aToken,
             groupKey.core.xToken,
@@ -140,9 +138,9 @@ contract MilkAvaxAIDecoderAndSanitizer is
         );
     }
 
-    function deposit(uint256) 
-        external 
-        pure 
+    function deposit(uint256)
+        external
+        pure
         override(YakStrategyDecoderAndSanitizer, DeltaPrimeDecoderAndSanitizer, BlackholeDecoderAndSanitizer)
         returns (bytes memory addressesFound)
     {
@@ -150,9 +148,9 @@ contract MilkAvaxAIDecoderAndSanitizer is
         return addressesFound;
     }
 
-    function depositNativeToken() 
-        external 
-        pure 
+    function depositNativeToken()
+        external
+        pure
         override(DeltaPrimeDecoderAndSanitizer)
         returns (bytes memory addressesFound)
     {
@@ -160,9 +158,9 @@ contract MilkAvaxAIDecoderAndSanitizer is
         return addressesFound;
     }
 
-    function createWithdrawalIntent(uint256) 
-        external 
-        pure 
+    function createWithdrawalIntent(uint256)
+        external
+        pure
         override(DeltaPrimeDecoderAndSanitizer)
         returns (bytes memory addressesFound)
     {
@@ -170,9 +168,9 @@ contract MilkAvaxAIDecoderAndSanitizer is
         return addressesFound;
     }
 
-    function withdraw(uint256,uint256[] calldata) 
-        external 
-        pure 
+    function withdraw(uint256, uint256[] calldata)
+        external
+        pure
         override(DeltaPrimeDecoderAndSanitizer)
         returns (bytes memory addressesFound)
     {
@@ -180,20 +178,13 @@ contract MilkAvaxAIDecoderAndSanitizer is
         return addressesFound;
     }
 
-    function addLiquidity(
-        DecoderCustomTypes.LiquidityParameters calldata params
-    )
-        external 
-        pure 
-        override(LFJLBRouterDecoderAndSanitizer) 
+    function addLiquidity(DecoderCustomTypes.LiquidityParameters calldata params)
+        external
+        pure
+        override(LFJLBRouterDecoderAndSanitizer)
         returns (bytes memory addressesFound)
     {
-        addressesFound = abi.encodePacked(
-            params.tokenX,
-            params.tokenY,
-            params.to,
-            params.refundTo
-        );
+        addressesFound = abi.encodePacked(params.tokenX, params.tokenY, params.to, params.refundTo);
     }
 
     function removeLiquidity(
@@ -206,30 +197,25 @@ contract MilkAvaxAIDecoderAndSanitizer is
         uint256[] memory,
         address to,
         uint256
-    )
-        external 
-        pure 
-        override(LFJLBRouterDecoderAndSanitizer) 
-        returns (bytes memory addressesFound)
-    {
-        addressesFound = abi.encodePacked(
-            tokenX,
-            tokenY,
-            to
-        );
+    ) external pure override(LFJLBRouterDecoderAndSanitizer) returns (bytes memory addressesFound) {
+        addressesFound = abi.encodePacked(tokenX, tokenY, to);
     }
 
-    function claim(
-        address user,
-        uint256[] calldata
-    ) external pure override(LFJLBHooksSimpleRewarderDecoderAndSanitizer) returns (bytes memory addressesFound) {
+    function claim(address user, uint256[] calldata)
+        external
+        pure
+        override(LFJLBHooksSimpleRewarderDecoderAndSanitizer)
+        returns (bytes memory addressesFound)
+    {
         addressesFound = abi.encodePacked(user);
     }
 
-    function approveForAll(
-        address spender,
-        bool
-    ) external pure override(LFJLBPairDecoderAndSanitizer) returns (bytes memory addressesFound) {
+    function approveForAll(address spender, bool)
+        external
+        pure
+        override(LFJLBPairDecoderAndSanitizer)
+        returns (bytes memory addressesFound)
+    {
         addressesFound = abi.encodePacked(spender);
     }
 }

--- a/src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+
+interface IAaveV4Spoke {
+    struct Reserve {
+        address underlying;
+        address hub;
+        uint16 assetId;
+        uint8 decimals;
+        uint24 collateralRisk;
+        uint8 flags;
+        uint32 dynamicConfigKey;
+    }
+
+    function getReserve(uint256 reserveId) external view returns (Reserve memory);
+}
+
+abstract contract AaveV4DecoderAndSanitizer is BaseDecoderAndSanitizer {
+    //============================== IMMUTABLES ===============================
+
+    IAaveV4Spoke internal immutable aaveV4Spoke;
+
+    constructor(address _aaveV4Spoke) {
+        aaveV4Spoke = IAaveV4Spoke(_aaveV4Spoke);
+    }
+
+    //============================== AAVE V4 ===============================
+
+    function supply(uint256 reserveId, uint256, address onBehalfOf)
+        external
+        view
+        virtual
+        returns (bytes memory addressesFound)
+    {
+        addressesFound = _decodeReserveAndAccount(reserveId, onBehalfOf);
+    }
+
+    function borrow(uint256 reserveId, uint256, address onBehalfOf)
+        external
+        view
+        virtual
+        returns (bytes memory addressesFound)
+    {
+        addressesFound = _decodeReserveAndAccount(reserveId, onBehalfOf);
+    }
+
+    function repay(uint256 reserveId, uint256, address onBehalfOf)
+        external
+        view
+        virtual
+        returns (bytes memory addressesFound)
+    {
+        addressesFound = _decodeReserveAndAccount(reserveId, onBehalfOf);
+    }
+
+    function withdraw(uint256 reserveId, uint256, address onBehalfOf)
+        external
+        view
+        virtual
+        returns (bytes memory addressesFound)
+    {
+        addressesFound = _decodeReserveAndAccount(reserveId, onBehalfOf);
+    }
+
+    function _decodeReserveAndAccount(uint256 reserveId, address onBehalfOf)
+        internal
+        view
+        returns (bytes memory addressesFound)
+    {
+        IAaveV4Spoke.Reserve memory reserve = aaveV4Spoke.getReserve(reserveId);
+        addressesFound = abi.encodePacked(reserve.underlying, onBehalfOf);
+    }
+}

--- a/src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol
@@ -3,34 +3,16 @@ pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 
-interface IAaveV4Spoke {
-    struct Reserve {
-        address underlying;
-        address hub;
-        uint16 assetId;
-        uint8 decimals;
-        uint24 collateralRisk;
-        uint8 flags;
-        uint32 dynamicConfigKey;
-    }
-
-    function getReserve(uint256 reserveId) external view returns (Reserve memory);
-}
-
 abstract contract AaveV4DecoderAndSanitizer is BaseDecoderAndSanitizer {
-    //============================== IMMUTABLES ===============================
+    //============================== ERRORS ===============================
 
-    IAaveV4Spoke internal immutable aaveV4Spoke;
-
-    constructor(address _aaveV4Spoke) {
-        aaveV4Spoke = IAaveV4Spoke(_aaveV4Spoke);
-    }
+    error AaveV4DecoderAndSanitizer__ReserveIdTooLarge();
 
     //============================== AAVE V4 ===============================
 
     function supply(uint256 reserveId, uint256, address onBehalfOf)
         external
-        view
+        pure
         virtual
         returns (bytes memory addressesFound)
     {
@@ -39,7 +21,7 @@ abstract contract AaveV4DecoderAndSanitizer is BaseDecoderAndSanitizer {
 
     function borrow(uint256 reserveId, uint256, address onBehalfOf)
         external
-        view
+        pure
         virtual
         returns (bytes memory addressesFound)
     {
@@ -48,7 +30,7 @@ abstract contract AaveV4DecoderAndSanitizer is BaseDecoderAndSanitizer {
 
     function repay(uint256 reserveId, uint256, address onBehalfOf)
         external
-        view
+        pure
         virtual
         returns (bytes memory addressesFound)
     {
@@ -57,7 +39,7 @@ abstract contract AaveV4DecoderAndSanitizer is BaseDecoderAndSanitizer {
 
     function withdraw(uint256 reserveId, uint256, address onBehalfOf)
         external
-        view
+        pure
         virtual
         returns (bytes memory addressesFound)
     {
@@ -66,10 +48,14 @@ abstract contract AaveV4DecoderAndSanitizer is BaseDecoderAndSanitizer {
 
     function _decodeReserveAndAccount(uint256 reserveId, address onBehalfOf)
         internal
-        view
+        pure
         returns (bytes memory addressesFound)
     {
-        IAaveV4Spoke.Reserve memory reserve = aaveV4Spoke.getReserve(reserveId);
-        addressesFound = abi.encodePacked(reserve.underlying, onBehalfOf);
+        if (reserveId >= type(uint160).max) revert AaveV4DecoderAndSanitizer__ReserveIdTooLarge();
+
+        // The manager includes the target Spoke in each Merkle leaf. Encoding reserveId + 1
+        // as an address-shaped sentinel therefore constrains the exact local reserve without
+        // coupling this reusable decoder to one Spoke. Adding one keeps reserve ID zero nonzero.
+        addressesFound = abi.encodePacked(address(uint160(reserveId + 1)), onBehalfOf);
     }
 }

--- a/test/AaveV4DecoderAndSanitizer.t.sol
+++ b/test/AaveV4DecoderAndSanitizer.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test} from "forge-std/Test.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {
+    AaveV4DecoderAndSanitizer,
+    IAaveV4Spoke
+} from "src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol";
+
+contract MockAaveV4Spoke is IAaveV4Spoke {
+    mapping(uint256 => Reserve) internal reserves;
+
+    function setReserve(uint256 reserveId, address underlying) external {
+        reserves[reserveId].underlying = underlying;
+    }
+
+    function getReserve(uint256 reserveId) external view returns (Reserve memory) {
+        return reserves[reserveId];
+    }
+}
+
+contract TestAaveV4DecoderAndSanitizer is AaveV4DecoderAndSanitizer {
+    constructor(address boringVault, address spoke)
+        BaseDecoderAndSanitizer(boringVault)
+        AaveV4DecoderAndSanitizer(spoke)
+    {}
+}
+
+contract AaveV4DecoderAndSanitizerTest is Test {
+    MockAaveV4Spoke internal spoke;
+    TestAaveV4DecoderAndSanitizer internal decoder;
+
+    address internal constant BORING_VAULT = address(0xB0);
+    address internal constant WAVAX = address(0xA1);
+    address internal constant USDC = address(0xA2);
+    address internal constant ON_BEHALF_OF = address(0xBEEF);
+
+    function setUp() external {
+        spoke = new MockAaveV4Spoke();
+        spoke.setReserve(0, WAVAX);
+        spoke.setReserve(2, USDC);
+        decoder = new TestAaveV4DecoderAndSanitizer(BORING_VAULT, address(spoke));
+    }
+
+    function testSupplyReturnsUnderlyingAndOnBehalfOf() external {
+        assertEq(decoder.supply(2, 1e6, ON_BEHALF_OF), abi.encodePacked(USDC, ON_BEHALF_OF));
+    }
+
+    function testBorrowReturnsUnderlyingAndOnBehalfOf() external {
+        assertEq(decoder.borrow(2, 1e6, ON_BEHALF_OF), abi.encodePacked(USDC, ON_BEHALF_OF));
+    }
+
+    function testRepayReturnsUnderlyingAndOnBehalfOf() external {
+        assertEq(decoder.repay(2, 1e6, ON_BEHALF_OF), abi.encodePacked(USDC, ON_BEHALF_OF));
+    }
+
+    function testWithdrawReturnsUnderlyingAndOnBehalfOf() external {
+        assertEq(decoder.withdraw(2, 1e6, ON_BEHALF_OF), abi.encodePacked(USDC, ON_BEHALF_OF));
+    }
+
+    function testReserveIdChangesPackedUnderlying() external {
+        bytes memory wavaxAddresses = decoder.supply(0, 1 ether, ON_BEHALF_OF);
+        bytes memory usdcAddresses = decoder.supply(2, 1e6, ON_BEHALF_OF);
+
+        assertEq(wavaxAddresses, abi.encodePacked(WAVAX, ON_BEHALF_OF));
+        assertEq(usdcAddresses, abi.encodePacked(USDC, ON_BEHALF_OF));
+        assertNotEq(keccak256(wavaxAddresses), keccak256(usdcAddresses));
+    }
+}

--- a/test/AaveV4DecoderAndSanitizer.t.sol
+++ b/test/AaveV4DecoderAndSanitizer.t.sol
@@ -20,6 +20,21 @@ contract MockAaveV4Spoke is IAaveV4Spoke {
     }
 }
 
+contract RawAaveV4SpokeMock {
+    address public constant UNDERLYING = address(0xA3);
+    address public constant HUB = address(0xB3);
+
+    fallback() external {
+        require(msg.sig == IAaveV4Spoke.getReserve.selector);
+        bytes memory response = abi.encode(
+            UNDERLYING, HUB, type(uint16).max, type(uint8).max, type(uint24).max, type(uint8).max, type(uint32).max
+        );
+        assembly {
+            return(add(response, 0x20), mload(response))
+        }
+    }
+}
+
 contract TestAaveV4DecoderAndSanitizer is AaveV4DecoderAndSanitizer {
     constructor(address boringVault, address spoke)
         BaseDecoderAndSanitizer(boringVault)
@@ -66,5 +81,12 @@ contract AaveV4DecoderAndSanitizerTest is Test {
         assertEq(wavaxAddresses, abi.encodePacked(WAVAX, ON_BEHALF_OF));
         assertEq(usdcAddresses, abi.encodePacked(USDC, ON_BEHALF_OF));
         assertNotEq(keccak256(wavaxAddresses), keccak256(usdcAddresses));
+    }
+
+    function testDecodesRawAaveV4ReserveAbiWithPopulatedFields() external {
+        RawAaveV4SpokeMock rawSpoke = new RawAaveV4SpokeMock();
+        TestAaveV4DecoderAndSanitizer rawDecoder = new TestAaveV4DecoderAndSanitizer(BORING_VAULT, address(rawSpoke));
+
+        assertEq(rawDecoder.supply(5, 1e6, ON_BEHALF_OF), abi.encodePacked(rawSpoke.UNDERLYING(), ON_BEHALF_OF));
     }
 }

--- a/test/AaveV4DecoderAndSanitizer.t.sol
+++ b/test/AaveV4DecoderAndSanitizer.t.sol
@@ -3,90 +3,51 @@ pragma solidity 0.8.21;
 
 import {Test} from "forge-std/Test.sol";
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
-import {
-    AaveV4DecoderAndSanitizer,
-    IAaveV4Spoke
-} from "src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol";
-
-contract MockAaveV4Spoke is IAaveV4Spoke {
-    mapping(uint256 => Reserve) internal reserves;
-
-    function setReserve(uint256 reserveId, address underlying) external {
-        reserves[reserveId].underlying = underlying;
-    }
-
-    function getReserve(uint256 reserveId) external view returns (Reserve memory) {
-        return reserves[reserveId];
-    }
-}
-
-contract RawAaveV4SpokeMock {
-    address public constant UNDERLYING = address(0xA3);
-    address public constant HUB = address(0xB3);
-
-    fallback() external {
-        require(msg.sig == IAaveV4Spoke.getReserve.selector);
-        bytes memory response = abi.encode(
-            UNDERLYING, HUB, type(uint16).max, type(uint8).max, type(uint24).max, type(uint8).max, type(uint32).max
-        );
-        assembly {
-            return(add(response, 0x20), mload(response))
-        }
-    }
-}
+import {AaveV4DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol";
 
 contract TestAaveV4DecoderAndSanitizer is AaveV4DecoderAndSanitizer {
-    constructor(address boringVault, address spoke)
-        BaseDecoderAndSanitizer(boringVault)
-        AaveV4DecoderAndSanitizer(spoke)
-    {}
+    constructor(address boringVault) BaseDecoderAndSanitizer(boringVault) {}
 }
 
 contract AaveV4DecoderAndSanitizerTest is Test {
-    MockAaveV4Spoke internal spoke;
     TestAaveV4DecoderAndSanitizer internal decoder;
 
     address internal constant BORING_VAULT = address(0xB0);
-    address internal constant WAVAX = address(0xA1);
-    address internal constant USDC = address(0xA2);
     address internal constant ON_BEHALF_OF = address(0xBEEF);
 
     function setUp() external {
-        spoke = new MockAaveV4Spoke();
-        spoke.setReserve(0, WAVAX);
-        spoke.setReserve(2, USDC);
-        decoder = new TestAaveV4DecoderAndSanitizer(BORING_VAULT, address(spoke));
+        decoder = new TestAaveV4DecoderAndSanitizer(BORING_VAULT);
     }
 
-    function testSupplyReturnsUnderlyingAndOnBehalfOf() external {
-        assertEq(decoder.supply(2, 1e6, ON_BEHALF_OF), abi.encodePacked(USDC, ON_BEHALF_OF));
+    function testSupplyReturnsReserveIdSentinelAndOnBehalfOf() external {
+        assertEq(decoder.supply(2, 1e6, ON_BEHALF_OF), abi.encodePacked(address(3), ON_BEHALF_OF));
     }
 
-    function testBorrowReturnsUnderlyingAndOnBehalfOf() external {
-        assertEq(decoder.borrow(2, 1e6, ON_BEHALF_OF), abi.encodePacked(USDC, ON_BEHALF_OF));
+    function testBorrowReturnsReserveIdSentinelAndOnBehalfOf() external {
+        assertEq(decoder.borrow(2, 1e6, ON_BEHALF_OF), abi.encodePacked(address(3), ON_BEHALF_OF));
     }
 
-    function testRepayReturnsUnderlyingAndOnBehalfOf() external {
-        assertEq(decoder.repay(2, 1e6, ON_BEHALF_OF), abi.encodePacked(USDC, ON_BEHALF_OF));
+    function testRepayReturnsReserveIdSentinelAndOnBehalfOf() external {
+        assertEq(decoder.repay(2, 1e6, ON_BEHALF_OF), abi.encodePacked(address(3), ON_BEHALF_OF));
     }
 
-    function testWithdrawReturnsUnderlyingAndOnBehalfOf() external {
-        assertEq(decoder.withdraw(2, 1e6, ON_BEHALF_OF), abi.encodePacked(USDC, ON_BEHALF_OF));
+    function testWithdrawReturnsReserveIdSentinelAndOnBehalfOf() external {
+        assertEq(decoder.withdraw(2, 1e6, ON_BEHALF_OF), abi.encodePacked(address(3), ON_BEHALF_OF));
     }
 
-    function testReserveIdChangesPackedUnderlying() external {
-        bytes memory wavaxAddresses = decoder.supply(0, 1 ether, ON_BEHALF_OF);
-        bytes memory usdcAddresses = decoder.supply(2, 1e6, ON_BEHALF_OF);
-
-        assertEq(wavaxAddresses, abi.encodePacked(WAVAX, ON_BEHALF_OF));
-        assertEq(usdcAddresses, abi.encodePacked(USDC, ON_BEHALF_OF));
-        assertNotEq(keccak256(wavaxAddresses), keccak256(usdcAddresses));
+    function testReserveIdZeroUsesNonZeroSentinel() external {
+        assertEq(decoder.supply(0, 1 ether, ON_BEHALF_OF), abi.encodePacked(address(1), ON_BEHALF_OF));
     }
 
-    function testDecodesRawAaveV4ReserveAbiWithPopulatedFields() external {
-        RawAaveV4SpokeMock rawSpoke = new RawAaveV4SpokeMock();
-        TestAaveV4DecoderAndSanitizer rawDecoder = new TestAaveV4DecoderAndSanitizer(BORING_VAULT, address(rawSpoke));
+    function testReserveIdsProduceDistinctPackedArguments() external {
+        bytes memory reserveZero = decoder.supply(0, 1 ether, ON_BEHALF_OF);
+        bytes memory reserveOne = decoder.supply(1, 1 ether, ON_BEHALF_OF);
 
-        assertEq(rawDecoder.supply(5, 1e6, ON_BEHALF_OF), abi.encodePacked(rawSpoke.UNDERLYING(), ON_BEHALF_OF));
+        assertNotEq(keccak256(reserveZero), keccak256(reserveOne));
+    }
+
+    function testReserveIdTooLargeReverts() external {
+        vm.expectRevert(AaveV4DecoderAndSanitizer.AaveV4DecoderAndSanitizer__ReserveIdTooLarge.selector);
+        decoder.supply(type(uint160).max, 1 ether, ON_BEHALF_OF);
     }
 }


### PR DESCRIPTION
## Summary
- add reusable `AaveV4DecoderAndSanitizer` support for supply, borrow, repay, and withdraw
- sanitize each Spoke-local `reserveId` as `address(uint160(reserveId + 1))`
- preserve `onBehalfOf` in the sanitized output
- reject reserve IDs that cannot be represented safely as a nonzero address-shaped sentinel
- avoid binding the decoder to one immutable Spoke, allowing the same decoder to serve multiple Aave V4 markets
- do not modify any composite decoder or deployment

## Rationale
Aave V4 reserve IDs are local to each Spoke. The decoder receives operation calldata but not the call target, so resolving a numeric ID through one immutable Spoke is unsafe when the same decoder serves Core, AVAX Correlated, and Forex.

Each Merkle leaf already commits to the target Spoke. Packing the nonzero reserve-ID sentinel plus `onBehalfOf` therefore constrains the complete identity as:

`target Spoke + local reserve ID + onBehalfOf`

The `+1` keeps local reserve ID `0` distinct from `address(0)`.

## Validation
- `forge fmt --check src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol test/AaveV4DecoderAndSanitizer.t.sol`
- `forge test --match-contract AaveV4DecoderAndSanitizerTest -vv` — 7 passed
- `forge build --force` — 246 files compiled successfully
- `git diff --check`
