### PR TITLE
feat: decode Aave V4 collateral enablement

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol
@@ -7,6 +7,7 @@ abstract contract AaveV4DecoderAndSanitizer is BaseDecoderAndSanitizer {
     //============================== ERRORS ===============================
 
     error AaveV4DecoderAndSanitizer__ReserveIdTooLarge();
+    error AaveV4DecoderAndSanitizer__CollateralDisableNotAllowed();
 
     //============================== AAVE V4 ===============================
 
@@ -43,6 +44,16 @@ abstract contract AaveV4DecoderAndSanitizer is BaseDecoderAndSanitizer {
         virtual
         returns (bytes memory addressesFound)
     {
+        addressesFound = _decodeReserveAndAccount(reserveId, onBehalfOf);
+    }
+
+    function setUsingAsCollateral(uint256 reserveId, bool useAsCollateral, address onBehalfOf)
+        external
+        pure
+        virtual
+        returns (bytes memory addressesFound)
+    {
+        if (!useAsCollateral) revert AaveV4DecoderAndSanitizer__CollateralDisableNotAllowed();
         addressesFound = _decodeReserveAndAccount(reserveId, onBehalfOf);
     }
 

--- a/test/AaveV4DecoderAndSanitizer.t.sol
+++ b/test/AaveV4DecoderAndSanitizer.t.sol
@@ -35,6 +35,15 @@ contract AaveV4DecoderAndSanitizerTest is Test {
         assertEq(decoder.withdraw(2, 1e6, ON_BEHALF_OF), abi.encodePacked(address(3), ON_BEHALF_OF));
     }
 
+    function testSetUsingAsCollateralReturnsReserveIdSentinelAndOnBehalfOf() external {
+        assertEq(decoder.setUsingAsCollateral(2, true, ON_BEHALF_OF), abi.encodePacked(address(3), ON_BEHALF_OF));
+    }
+
+    function testSetUsingAsCollateralRejectsDisablingCollateral() external {
+        vm.expectRevert(AaveV4DecoderAndSanitizer.AaveV4DecoderAndSanitizer__CollateralDisableNotAllowed.selector);
+        decoder.setUsingAsCollateral(2, false, ON_BEHALF_OF);
+    }
+
     function testReserveIdZeroUsesNonZeroSentinel() external {
         assertEq(decoder.supply(0, 1 ether, ON_BEHALF_OF), abi.encodePacked(address(1), ON_BEHALF_OF));
     }


### PR DESCRIPTION
## Summary
- decode Aave V4 `setUsingAsCollateral(uint256,bool,address)` calls
- bind permissions to the market-local reserve sentinel and `onBehalfOf` account
- reject collateral-disable calls so an enable-only Merkle leaf cannot be reused to disable collateral
- add focused tests for encoding and the enable-only restriction

## Why
Aave V4 supply positions are not automatically enabled as collateral. Borrowing against sAVAX on the AVAX Correlated Spoke therefore requires a one-time `setUsingAsCollateral(0, true, vault)` call.

## Security
- reserve IDs retain the existing nonzero `reserveId + 1` sentinel encoding
- `onBehalfOf` remains bound in sanitized calldata
- `false` reverts in the decoder, so the authorized selector cannot disable collateral
- the manager's target-bound leaf continues to isolate identical local reserve IDs across Spokes

## Validation
- `forge fmt --check src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol test/AaveV4DecoderAndSanitizer.t.sol`
- `forge test --match-contract AaveV4DecoderAndSanitizerTest -vv` (9 passed)
- `forge build --force` (246 files compiled)

## Deployment note
A new decoder deployment is required before a Merkle tree can execute this selector. The companion scripts PR intentionally documents this dependency.
