### PR TITLE
feat: add Aave V4 to aiUSD and aiBTC decoders

### DIFF
--- a/src/base/DecodersAndSanitizers/MilkBTCAIDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/MilkBTCAIDecoderAndSanitizer.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {AaveV3DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/AaveV3DecoderAndSanitizer.sol";
+import {AaveV4DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol";
 import {AesyxBorrowerOperations} from "src/base/DecodersAndSanitizers/Protocols/aesyx/AesyxBorrowerOperations.sol";
 import {AesyxStabilityPool} from "src/base/DecodersAndSanitizers/Protocols/aesyx/AesyxStabilityPool.sol";
 import {AesyxWrapper} from "src/base/DecodersAndSanitizers/Protocols/aesyx/AesyxWrapper.sol";
@@ -26,6 +27,7 @@ import {YakSimpleSwapDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/P
 contract MilkBTCAIDecoderAndSanitizer is
     BaseDecoderAndSanitizer,
     AaveV3DecoderAndSanitizer,
+    AaveV4DecoderAndSanitizer,
     AesyxBorrowerOperations,
     AesyxStabilityPool,
     AesyxWrapper,

--- a/src/base/DecodersAndSanitizers/MilkUSDAIDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/MilkUSDAIDecoderAndSanitizer.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {AaveV3DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/AaveV3DecoderAndSanitizer.sol";
+import {AaveV4DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol";
 import {AvantMintingV2} from "src/base/DecodersAndSanitizers/Protocols/avant/AvantMintingV2.sol";
 import {AvantReferralRegistry} from "src/base/DecodersAndSanitizers/Protocols/avant/AvantReferralRegistry.sol";
 import {BenqiLendingDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/benqi/BenqiLendingDecoderAndSanitizer.sol";
@@ -30,6 +31,7 @@ import {YakSimpleSwapDecoderAndSanitizer} from
 contract MilkUSDAIDecoderAndSanitizer is
     BaseDecoderAndSanitizer,
     AaveV3DecoderAndSanitizer,
+    AaveV4DecoderAndSanitizer,
     AvantMintingV2,
     AvantReferralRegistry,
     BenqiLendingDecoderAndSanitizer,

--- a/test/MilkAIAaveV4DecoderAndSanitizer.t.sol
+++ b/test/MilkAIAaveV4DecoderAndSanitizer.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test} from "forge-std/Test.sol";
+import {AaveV4DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/AaveV4DecoderAndSanitizer.sol";
+import {MilkBTCAIDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/MilkBTCAIDecoderAndSanitizer.sol";
+import {MilkUSDAIDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/MilkUSDAIDecoderAndSanitizer.sol";
+
+interface IAaveV4Decoder {
+    function supply(uint256 reserveId, uint256 amount, address onBehalfOf) external pure returns (bytes memory);
+    function borrow(uint256 reserveId, uint256 amount, address onBehalfOf) external pure returns (bytes memory);
+    function repay(uint256 reserveId, uint256 amount, address onBehalfOf) external pure returns (bytes memory);
+    function withdraw(uint256 reserveId, uint256 amount, address onBehalfOf) external pure returns (bytes memory);
+    function setUsingAsCollateral(uint256 reserveId, bool useAsCollateral, address onBehalfOf)
+        external
+        pure
+        returns (bytes memory);
+}
+
+contract MilkAIAaveV4DecoderAndSanitizerTest is Test {
+    address internal constant BORING_VAULT = address(0xB0);
+    address internal constant POSITION_MANAGER = address(0xB1);
+    address internal constant ON_BEHALF_OF = address(0xBEEF);
+
+    IAaveV4Decoder internal aiUsdDecoder;
+    IAaveV4Decoder internal aiBtcDecoder;
+
+    function setUp() external {
+        aiUsdDecoder = IAaveV4Decoder(address(new MilkUSDAIDecoderAndSanitizer(BORING_VAULT, POSITION_MANAGER)));
+        aiBtcDecoder = IAaveV4Decoder(address(new MilkBTCAIDecoderAndSanitizer(BORING_VAULT, POSITION_MANAGER)));
+    }
+
+    function testAiUsdDecoderSupportsAaveV4() external {
+        _assertAaveV4Routes(aiUsdDecoder);
+    }
+
+    function testAiBtcDecoderSupportsAaveV4() external {
+        _assertAaveV4Routes(aiBtcDecoder);
+    }
+
+    function testAiUsdDecoderRejectsDisablingAaveV4Collateral() external {
+        vm.expectRevert(AaveV4DecoderAndSanitizer.AaveV4DecoderAndSanitizer__CollateralDisableNotAllowed.selector);
+        aiUsdDecoder.setUsingAsCollateral(2, false, ON_BEHALF_OF);
+    }
+
+    function testAiBtcDecoderRejectsDisablingAaveV4Collateral() external {
+        vm.expectRevert(AaveV4DecoderAndSanitizer.AaveV4DecoderAndSanitizer__CollateralDisableNotAllowed.selector);
+        aiBtcDecoder.setUsingAsCollateral(1, false, ON_BEHALF_OF);
+    }
+
+    function _assertAaveV4Routes(IAaveV4Decoder decoder) internal {
+        bytes memory expected = abi.encodePacked(address(3), ON_BEHALF_OF);
+
+        assertEq(decoder.supply(2, 1e6, ON_BEHALF_OF), expected);
+        assertEq(decoder.borrow(2, 1e6, ON_BEHALF_OF), expected);
+        assertEq(decoder.repay(2, 1e6, ON_BEHALF_OF), expected);
+        assertEq(decoder.withdraw(2, 1e6, ON_BEHALF_OF), expected);
+        assertEq(decoder.setUsingAsCollateral(2, true, ON_BEHALF_OF), expected);
+    }
+}


### PR DESCRIPTION
## Summary
- add the existing `AaveV4DecoderAndSanitizer` to the concrete aiUSD decoder
- add the existing `AaveV4DecoderAndSanitizer` to the concrete aiBTC decoder
- verify both concrete decoders expose Aave V4 supply, borrow, repay, withdraw, and collateral-enablement routes
- verify both reject `setUsingAsCollateral(..., false, ...)`

This provides the two decoder deployments required by yieldyak/boring-vault-scripts#44. The existing aiUSD and aiBTC redeployment scripts can be used without modification.

## Deployment

### aiUSD

```bash
forge script script/ArchitectureDeployments/Avalanche/yyUSDai/RedeployUSDMilkAIDecoderAndSanitizer.s.sol:RedeployUSDMilkAIDecoderAndSanitizer --account yak-deployer --broadcast --verifier-url 'https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan' --etherscan-api-key "verifyContract" --verify
```

### aiBTC

```bash
forge script script/ArchitectureDeployments/Avalanche/yyBTCai/RedeployBTCMilkAIDecoderAndSanitizer.s.sol:RedeployBTCMilkAIDecoderAndSanitizer --account yak-deployer --broadcast --verifier-url 'https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan' --etherscan-api-key "verifyContract" --verify
```

## Validation
- `forge build --force`
- `forge build --sizes` — aiBTC runtime 6,619 B; aiUSD runtime 6,238 B, both well below the 24,576 B limit
- `forge test --match-path 'test/*AaveV4DecoderAndSanitizer.t.sol' -vv` — 13 passed
- `git diff --check`

A full `forge test` run executes the same 13 tests successfully; nine unrelated fork-based suites cannot initialize in this environment because `SEPOLIA_RPC_URL` is not configured.
