### PR TITLE
fix: add YakMilk support to aiUSD decoder

### DIFF
--- a/src/base/DecodersAndSanitizers/MilkUSDAIDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/MilkUSDAIDecoderAndSanitizer.sol
@@ -23,6 +23,7 @@ import {MerklDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols
 import {NativeWrapperDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/NativeWrapperDecoderAndSanitizer.sol";
 import {SparkRewardsDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/SparkRewardsDecoderAndSanitizer.sol";
 import {Silo} from "src/base/DecodersAndSanitizers/Protocols/silo/Silo.sol";
+import {YakMilkDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/YakMilkDecoderAndSanitizer.sol";
 import {YakStrategyDecoderAndSanitizer} from
     "src/base/DecodersAndSanitizers/Protocols/YakStrategyDecoderAndSanitizer.sol";
 import {YakSimpleSwapDecoderAndSanitizer} from
@@ -47,6 +48,7 @@ contract MilkUSDAIDecoderAndSanitizer is
     NativeWrapperDecoderAndSanitizer,
     Silo,
     SparkRewardsDecoderAndSanitizer,
+    YakMilkDecoderAndSanitizer,
     YakStrategyDecoderAndSanitizer,
     YakSimpleSwapDecoderAndSanitizer
 {

--- a/test/MilkUSDAIYakMilkDecoderAndSanitizer.t.sol
+++ b/test/MilkUSDAIYakMilkDecoderAndSanitizer.t.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test} from "forge-std/Test.sol";
+import {MilkUSDAIDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/MilkUSDAIDecoderAndSanitizer.sol";
+
+interface IYakMilkDecoder {
+    function deposit(address depositAsset, uint256 amount, uint256 minimumMint) external pure returns (bytes memory);
+    function requestWithdraw(address asset, uint96 shares, uint16 maxLoss, bool allowThirdPartyToComplete)
+        external
+        pure
+        returns (bytes memory);
+}
+
+contract MilkUSDAIYakMilkDecoderAndSanitizerTest is Test {
+    address internal constant BORING_VAULT = address(0xB0);
+    address internal constant POSITION_MANAGER = address(0xB1);
+    address internal constant ASSET = address(0xA55E7);
+
+    IYakMilkDecoder internal decoder;
+
+    function setUp() external {
+        decoder = IYakMilkDecoder(address(new MilkUSDAIDecoderAndSanitizer(BORING_VAULT, POSITION_MANAGER)));
+    }
+
+    function testDepositSanitizesDepositAsset() external {
+        assertEq(decoder.deposit(ASSET, 1e6, 1e18), abi.encodePacked(ASSET));
+    }
+
+    function testRequestWithdrawSanitizesAsset() external {
+        assertEq(decoder.requestWithdraw(ASSET, 1e18, 100, true), abi.encodePacked(ASSET));
+    }
+}


### PR DESCRIPTION
## Summary

- add `YakMilkDecoderAndSanitizer` inheritance to the aiUSD decoder
- restore decoding for `deposit(address,uint256,uint256)` and `requestWithdraw(address,uint96,uint16,bool)` used by the existing Milk vault Merkle leaves
- add regression tests proving both selectors sanitize only the Milk asset address

## Root cause

`MilkUSDAIDecoderAndSanitizer` did not inherit `YakMilkDecoderAndSanitizer`, unlike the aiAVAX and aiBTC decoders. As a result, the configured aiUSD deployer decoder reverted on the existing Milk vault `requestWithdraw` selector even though the Merkle tree authorized that operation.

## Validation

- live configured decoder call reproduced the selector revert
- `forge test --match-contract MilkUSDAIYakMilkDecoderAndSanitizerTest -vvv` — 2 passed
- `forge build --force` — passed
- `forge fmt --check test/MilkUSDAIYakMilkDecoderAndSanitizer.t.sol` — passed
- `git diff --check` — passed

The remaining full-suite failures require the unavailable `SEPOLIA_RPC_URL`; all locally runnable tests passed.
