### PR TITLE
fix: add Merkl support to yiUSD decoder

### DIFF
--- a/src/base/DecodersAndSanitizers/IntelligentUSDBaseDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/IntelligentUSDBaseDecoderAndSanitizer.sol
@@ -14,6 +14,7 @@ import {
 import {
     MorphoBlueDecoderAndSanitizer
 } from "src/base/DecodersAndSanitizers/Protocols/MorphoBlueDecoderAndSanitizer.sol";
+import {MerklDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/MerklDecoderAndSanitizer.sol";
 import {YoDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/YoDecoderAndSanitizer.sol";
 
 contract IntelligentUSDBaseDecoderAndSanitizer is
@@ -24,6 +25,7 @@ contract IntelligentUSDBaseDecoderAndSanitizer is
     VelodromeDecoderAndSanitizer,
     YakSimpleSwapDecoderAndSanitizer,
     MorphoBlueDecoderAndSanitizer,
+    MerklDecoderAndSanitizer,
     YoDecoderAndSanitizer
 {
     constructor(address _boringVault, address _velodromeNonFungiblePositionManager)

--- a/test/IntelligentUSDBaseMerklDecoderAndSanitizer.t.sol
+++ b/test/IntelligentUSDBaseMerklDecoderAndSanitizer.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test} from "forge-std/Test.sol";
+import {
+    IntelligentUSDBaseDecoderAndSanitizer
+} from "src/base/DecodersAndSanitizers/IntelligentUSDBaseDecoderAndSanitizer.sol";
+import {MerklDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/MerklDecoderAndSanitizer.sol";
+
+interface IMerklDecoder {
+    function claim(
+        address[] calldata users,
+        address[] calldata tokens,
+        uint256[] calldata amounts,
+        bytes32[][] calldata proofs
+    ) external pure returns (bytes memory);
+}
+
+contract IntelligentUSDBaseMerklDecoderAndSanitizerTest is Test {
+    address internal constant YIUSD = 0xB5803023B8fa8BFe7d64E373297dFaA24e3B5962;
+    address internal constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+    address internal constant POSITION_MANAGER = address(0xB1);
+
+    IMerklDecoder internal decoder;
+
+    function setUp() external {
+        decoder = IMerklDecoder(address(new IntelligentUSDBaseDecoderAndSanitizer(YIUSD, POSITION_MANAGER)));
+    }
+
+    function testClaimSanitizesUserAndToken() external {
+        address[] memory users = new address[](1);
+        users[0] = YIUSD;
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = USDC;
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1e6;
+
+        bytes32[][] memory proofs = new bytes32[][](1);
+        proofs[0] = new bytes32[](0);
+
+        assertEq(decoder.claim(users, tokens, amounts, proofs), abi.encodePacked(YIUSD, USDC));
+    }
+
+    function testClaimRejectsMismatchedArrayLengths() external {
+        address[] memory users = new address[](1);
+        users[0] = YIUSD;
+
+        address[] memory tokens = new address[](0);
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1e6;
+
+        bytes32[][] memory proofs = new bytes32[][](1);
+        proofs[0] = new bytes32[](0);
+
+        vm.expectRevert(MerklDecoderAndSanitizer.MerklDecoderAndSanitizer__InputLengthMismatch.selector);
+        decoder.claim(users, tokens, amounts, proofs);
+    }
+}


### PR DESCRIPTION
## Summary

- add `MerklDecoderAndSanitizer` support to the Base yiUSD decoder
- enable sanitization of Merkl `claim(address[],address[],uint256[],bytes32[][])` calldata
- add regression coverage for valid yiUSD/Base-USDC claims and mismatched input arrays

## Root cause

The configured yiUSD decoder reverted on selector `0x71ee95c0` because `IntelligentUSDBaseDecoderAndSanitizer` did not inherit the existing Merkl sanitizer. The yiUSD Merkle tree already contains constrained Merkl leaves, but the manager could not decode the corresponding claim calldata.

## Security properties

The inherited sanitizer:

- requires users, tokens, amounts, and proofs to have equal lengths
- includes every `(user, token)` pair in the sanitized output
- leaves amounts and proofs unconstrained, matching Merkl's cumulative-claim design and the existing permission template

The yiUSD permissions separately constrain the claim target to the Merkl distributor and the sanitized values to the yiUSD vault and approved reward token.

## Validation

- reproduced the missing selector against the configured decoder on Base
- TDD regression test failed with the expected unrecognized selector before the fix
- focused Merkl decoder tests: 2 passed
- all decoder tests: 17 passed
- `forge build --force`: passed
- formatting and diff checks: passed
